### PR TITLE
open quickfix even job is successful

### DIFF
--- a/autoload/async.vim
+++ b/autoload/async.vim
@@ -387,6 +387,10 @@ fun! s:cb_quickfix(job) abort
 
   elseif !status && empty(job.err)
     echo "Success:" job.title
+    " open quickfix even job is successful
+    if job.openqf && canopen
+      call s:open_qfix(job)
+    endif
 
   elseif failure
     call s:echo(['Exit status: '. status, 'Command: '. job.title]


### PR DESCRIPTION
Sometimes command returns 0, but user still want to see the result. For example, it's useful for locate.
```vim
command! -nargs=* Locate async#qfix(<q-args>, {'errorformat': "%f", "makeprg": "locate"})
```